### PR TITLE
Allow hash mismatch in NODE_ENV=development

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check-formatting": "./node_modules/.bin/prettier '**/*.ts' --list-different",
     "fix-formatting": "./node_modules/.bin/prettier '**/*.ts' --write",
     "lint": "npm run tslint && npm run check-formatting",
-    "tslint": "tslint 'src/**/*.ts' --type-check --project tsconfig.json --format verbose",
+    "tslint": "tslint 'src/**/*.ts' --project tsconfig.json --format verbose",
     "test-integration": "ava --config ava.config.integration.cjs",
     "test-unit": "ava --config ava.config.unit.cjs",
     "test": "npm run test-unit && npm run lint && npm run test-integration",

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -11,7 +11,7 @@ import {
   Migration,
   MigrationError,
 } from "./types"
-import {validateMigrationHashes} from "./validation"
+import {maybeValidateMigrationHashes} from "./validation"
 import {withConnection} from "./with-connection"
 import {withAdvisoryLock} from "./with-lock"
 
@@ -119,7 +119,7 @@ function runMigrations(intendedMigrations: Array<Migration>, log: Logger) {
         log,
       )
 
-      validateMigrationHashes(intendedMigrations, appliedMigrations)
+      maybeValidateMigrationHashes(intendedMigrations, appliedMigrations)
 
       const migrationsToRun = filterMigrations(
         intendedMigrations,

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -27,7 +27,7 @@ export function maybeValidateMigrationHashes(
   const invalidHashes = migrations.filter(invalidHash)
   if (invalidHashes.length > 0) {
     // Someone has altered one or more migrations which has already run - gasp!
-    const invalidFiles = invalidHashes.map(({ fileName }) => fileName)
+    const invalidFiles = invalidHashes.map(({fileName}) => fileName)
 
     if (process.env.NODE_ENV === "development") {
       console.error(`Hashes don't match for migrations '${invalidFiles}' but allowing 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -14,7 +14,7 @@ export function validateMigrationOrdering(migrations: Array<Migration>) {
 }
 
 /** Assert hashes match */
-export function validateMigrationHashes(
+export function maybeValidateMigrationHashes(
   migrations: Array<Migration>,
   appliedMigrations: Record<number, Migration | undefined>,
 ) {
@@ -27,8 +27,14 @@ export function validateMigrationHashes(
   const invalidHashes = migrations.filter(invalidHash)
   if (invalidHashes.length > 0) {
     // Someone has altered one or more migrations which has already run - gasp!
-    const invalidFiles = invalidHashes.map(({fileName}) => fileName)
-    throw new Error(`Hashes don't match for migrations '${invalidFiles}'.
+    const invalidFiles = invalidHashes.map(({ fileName }) => fileName)
+
+    if (process.env.NODE_ENV === "development") {
+      console.error(`Hashes don't match for migrations '${invalidFiles}' but allowing 
+as NODE_ENV is 'development'.`)
+    } else {
+      throw new Error(`Hashes don't match for migrations '${invalidFiles}'. 
 This means that the scripts have changed since it was applied.`)
+    }
   }
 }


### PR DESCRIPTION
Let's say during local development with a local database, you write a migration file. That file gets reformatted in a git hook. Now you're stuck with a migration file that doesn't match the hash in the local database. postgres-migrations currently provides no way to untangle that situation short of manual editing of the internal hash tracking database.

This PR warns but permits mismatched hashes on migration files in NODE_ENV=development. All other migration checks remain.